### PR TITLE
Add core domain entities with validation and tests

### DIFF
--- a/src/domain/entities/match.py
+++ b/src/domain/entities/match.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from ..value_objects.enums import MatchStatus
+from ..value_objects.ids import FixtureId, LeagueId
+
+
+class Match(BaseModel):
+    fixture_id: FixtureId = Field(..., description="Unique identifier for the fixture")
+    league_id: LeagueId = Field(..., description="League identifier")
+    season: int = Field(..., ge=0, description="Season year")
+    kickoff_utc: datetime = Field(..., description="Kickoff time in UTC")
+    home_name: str = Field(..., description="Home team name")
+    away_name: str = Field(..., description="Away team name")
+    status: MatchStatus = Field(..., description="Current match status")
+    ft_home_goals: int | None = Field(
+        default=None, description="Full-time goals for home team if match finished"
+    )
+    ft_away_goals: int | None = Field(
+        default=None, description="Full-time goals for away team if match finished"
+    )
+
+    model_config = ConfigDict(frozen=True)
+
+    @field_validator("kickoff_utc", mode="before")
+    @classmethod
+    def _ensure_utc(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError("kickoff_utc must be timezone-aware")
+        return v.astimezone(timezone.utc)
+
+    @model_validator(mode="after")
+    def _require_score_if_finished(self) -> "Match":
+        if self.status == MatchStatus.FINISHED:
+            if self.ft_home_goals is None or self.ft_away_goals is None:
+                raise ValueError("Finished match must have full-time goals set")
+        return self

--- a/src/domain/entities/odds.py
+++ b/src/domain/entities/odds.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Literal, Sequence
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from ..value_objects.enums import Outcome
+from ..value_objects.ids import BookmakerId, FixtureId
+from ..value_objects.probability_triplet import ProbabilityTriplet
+
+
+class Odds(BaseModel):
+    fixture_id: FixtureId
+    bookmaker_id: BookmakerId
+    collected_at_utc: datetime
+    home: Decimal
+    draw: Decimal
+    away: Decimal
+    market: Literal["1x2"] = "1x2"
+
+    model_config = ConfigDict(frozen=True)
+
+    @field_validator("collected_at_utc", mode="before")
+    @classmethod
+    def _ensure_utc(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError("collected_at_utc must be timezone-aware")
+        return v.astimezone(timezone.utc)
+
+    @field_validator("home", "draw", "away")
+    @classmethod
+    def _check_minimum(cls, v: Decimal) -> Decimal:
+        if v < Decimal("1.01"):
+            raise ValueError("Odds must be at least 1.01")
+        return v
+
+    def implied_probabilities(self) -> ProbabilityTriplet:
+        odds = [self.home, self.draw, self.away]
+        return ProbabilityTriplet.from_odds(odds)
+
+
+def best_of(odds_list: Sequence[Odds]) -> dict[Outcome, tuple[BookmakerId, Decimal]]:
+    best: dict[Outcome, tuple[BookmakerId, Decimal]] = {}
+    for o in odds_list:
+        if (Outcome.HOME not in best) or (o.home > best[Outcome.HOME][1]):
+            best[Outcome.HOME] = (o.bookmaker_id, o.home)
+        if (Outcome.DRAW not in best) or (o.draw > best[Outcome.DRAW][1]):
+            best[Outcome.DRAW] = (o.bookmaker_id, o.draw)
+        if (Outcome.AWAY not in best) or (o.away > best[Outcome.AWAY][1]):
+            best[Outcome.AWAY] = (o.bookmaker_id, o.away)
+    return best

--- a/src/domain/entities/prediction.py
+++ b/src/domain/entities/prediction.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Sequence, Tuple
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from ..value_objects.enums import ModelName, Outcome, PredictionStatus
+from ..value_objects.ids import BookmakerId, FixtureId
+from ..value_objects.probability_triplet import ProbabilityTriplet
+from .odds import Odds
+
+
+class Prediction(BaseModel):
+    fixture_id: FixtureId
+    model: ModelName
+    probs: ProbabilityTriplet | None = None
+    computed_at_utc: datetime
+    version: str
+    status: PredictionStatus
+    skip_reason: str | None = None
+
+    model_config = ConfigDict(frozen=True)
+
+    @field_validator("computed_at_utc", mode="before")
+    @classmethod
+    def _ensure_utc(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError("computed_at_utc must be timezone-aware")
+        return v.astimezone(timezone.utc)
+
+    @model_validator(mode="after")
+    def _check_status_requirements(self) -> "Prediction":
+        if self.status == PredictionStatus.OK and self.probs is None:
+            raise ValueError("probs must be provided when status is OK")
+        if self.status == PredictionStatus.SKIPPED and not self.skip_reason:
+            raise ValueError("skip_reason must be provided when status is SKIPPED")
+        return self
+
+    def ev(self, odds: Odds, outcome: Outcome) -> Decimal:
+        if self.probs is None:
+            raise ValueError("Cannot compute EV without probabilities")
+        prob_map = {
+            Outcome.HOME: self.probs.home,
+            Outcome.DRAW: self.probs.draw,
+            Outcome.AWAY: self.probs.away,
+        }
+        odds_map = {Outcome.HOME: odds.home, Outcome.DRAW: odds.draw, Outcome.AWAY: odds.away}
+        probability = Decimal(str(prob_map[outcome]))
+        return probability * odds_map[outcome] - Decimal("1")
+
+    def best_ev(self, odds_candidates: Sequence[Odds]) -> Tuple[Outcome, BookmakerId, Decimal]:
+        best_outcome: Outcome | None = None
+        best_bookmaker: BookmakerId | None = None
+        best_value = Decimal("-Infinity")
+        for o in odds_candidates:
+            for outcome in Outcome:
+                value = self.ev(o, outcome)
+                if value > best_value:
+                    best_value = value
+                    best_outcome = outcome
+                    best_bookmaker = o.bookmaker_id
+        assert best_outcome is not None and best_bookmaker is not None
+        return best_outcome, best_bookmaker, best_value

--- a/src/domain/entities/strategy_result.py
+++ b/src/domain/entities/strategy_result.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..value_objects.enums import ModelName, Outcome, StrategyName
+from ..value_objects.ids import FixtureId
+from ..value_objects.money import Money
+
+
+class StrategyResult(BaseModel):
+    fixture_id: FixtureId
+    strategy: StrategyName
+    model: ModelName
+    outcome: Outcome
+    stake: Money
+    odds: Decimal
+    result: Literal["WIN", "LOSE", "VOID"] | None = None
+    profit: Money
+    bankroll_after: Money
+    step_index: int = Field(..., ge=0)
+    notes: str | None = None
+
+    model_config = ConfigDict(frozen=True)

--- a/src/domain/value_objects/enums.py
+++ b/src/domain/value_objects/enums.py
@@ -1,6 +1,19 @@
 from enum import Enum
 
 
+class MatchStatus(str, Enum):
+    SCHEDULED = "SCHEDULED"
+    LIVE = "LIVE"
+    FINISHED = "FINISHED"
+    POSTPONED = "POSTPONED"
+    CANCELED = "CANCELED"
+
+
+class PredictionStatus(str, Enum):
+    OK = "OK"
+    SKIPPED = "SKIPPED"
+
+
 class ModelName(str, Enum):
     POISSON = "poisson"
     MONTE_CARLO = "monte_carlo"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,155 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from src.domain.entities.match import Match
+from src.domain.entities.odds import Odds, best_of
+from src.domain.entities.prediction import Prediction
+from src.domain.entities.strategy_result import StrategyResult
+from src.domain.value_objects.enums import (
+    MatchStatus,
+    ModelName,
+    Outcome,
+    PredictionStatus,
+    StrategyName,
+)
+from src.domain.value_objects.ids import BookmakerId, FixtureId, LeagueId
+from src.domain.value_objects.money import Money
+from src.domain.value_objects.probability_triplet import ProbabilityTriplet
+
+
+def test_match_requires_utc_and_scores() -> None:
+    with pytest.raises(ValueError):
+        Match(
+            fixture_id=FixtureId(1),
+            league_id=LeagueId(2),
+            season=2024,
+            kickoff_utc=datetime(2024, 5, 1),
+            home_name="A",
+            away_name="B",
+            status=MatchStatus.SCHEDULED,
+        )
+    with pytest.raises(ValueError):
+        Match(
+            fixture_id=FixtureId(1),
+            league_id=LeagueId(2),
+            season=2024,
+            kickoff_utc=datetime(2024, 5, 1, tzinfo=timezone.utc),
+            home_name="A",
+            away_name="B",
+            status=MatchStatus.FINISHED,
+        )
+    m = Match(
+        fixture_id=FixtureId(1),
+        league_id=LeagueId(2),
+        season=2024,
+        kickoff_utc=datetime(2024, 5, 1, tzinfo=timezone.utc),
+        home_name="A",
+        away_name="B",
+        status=MatchStatus.FINISHED,
+        ft_home_goals=1,
+        ft_away_goals=0,
+    )
+    assert m.ft_home_goals == 1
+
+
+def test_odds_validation_and_best_of() -> None:
+    with pytest.raises(ValueError):
+        Odds(
+            fixture_id=FixtureId(1),
+            bookmaker_id=BookmakerId(1),
+            collected_at_utc=datetime.now(timezone.utc),
+            home=Decimal("1.0"),
+            draw=Decimal("2.0"),
+            away=Decimal("3.0"),
+        )
+    o1 = Odds(
+        fixture_id=FixtureId(1),
+        bookmaker_id=BookmakerId(1),
+        collected_at_utc=datetime.now(timezone.utc),
+        home=Decimal("2.0"),
+        draw=Decimal("3.0"),
+        away=Decimal("4.0"),
+    )
+    o2 = Odds(
+        fixture_id=FixtureId(1),
+        bookmaker_id=BookmakerId(2),
+        collected_at_utc=datetime.now(timezone.utc),
+        home=Decimal("2.5"),
+        draw=Decimal("2.5"),
+        away=Decimal("4.5"),
+    )
+    probs = o1.implied_probabilities()
+    assert pytest.approx(probs.home + probs.draw + probs.away, 1e-9) == 1
+    best = best_of([o1, o2])
+    assert best[Outcome.HOME] == (BookmakerId(2), Decimal("2.5"))
+    assert best[Outcome.AWAY] == (BookmakerId(2), Decimal("4.5"))
+
+
+def test_prediction_ev_and_best_ev() -> None:
+    probs = ProbabilityTriplet(home=0.5, draw=0.3, away=0.2)
+    pred = Prediction(
+        fixture_id=FixtureId(1),
+        model=ModelName.POISSON,
+        probs=probs,
+        computed_at_utc=datetime.now(timezone.utc),
+        version="1.0",
+        status=PredictionStatus.OK,
+    )
+    odds = Odds(
+        fixture_id=FixtureId(1),
+        bookmaker_id=BookmakerId(1),
+        collected_at_utc=datetime.now(timezone.utc),
+        home=Decimal("2.0"),
+        draw=Decimal("3.0"),
+        away=Decimal("4.0"),
+    )
+    ev_home = pred.ev(odds, Outcome.HOME)
+    assert ev_home == Decimal("0")
+    o2 = Odds(
+        fixture_id=FixtureId(1),
+        bookmaker_id=BookmakerId(2),
+        collected_at_utc=datetime.now(timezone.utc),
+        home=Decimal("2.5"),
+        draw=Decimal("2.5"),
+        away=Decimal("4.5"),
+    )
+    outcome, bookmaker, value = pred.best_ev([odds, o2])
+    assert outcome == Outcome.HOME
+    assert bookmaker == BookmakerId(2)
+    assert value == pred.ev(o2, Outcome.HOME)
+
+
+def test_prediction_status_requirements() -> None:
+    with pytest.raises(ValueError):
+        Prediction(
+            fixture_id=FixtureId(1),
+            model=ModelName.POISSON,
+            computed_at_utc=datetime.now(timezone.utc),
+            version="1.0",
+            status=PredictionStatus.OK,
+        )
+    with pytest.raises(ValueError):
+        Prediction(
+            fixture_id=FixtureId(1),
+            model=ModelName.POISSON,
+            computed_at_utc=datetime.now(timezone.utc),
+            version="1.0",
+            status=PredictionStatus.SKIPPED,
+        )
+
+
+def test_strategy_result_creation() -> None:
+    res = StrategyResult(
+        fixture_id=FixtureId(1),
+        strategy=StrategyName.FLAT,
+        model=ModelName.POISSON,
+        outcome=Outcome.HOME,
+        stake=Money(amount=Decimal("10"), currency="EUR"),
+        odds=Decimal("2.0"),
+        profit=Money(amount=Decimal("10"), currency="EUR"),
+        bankroll_after=Money(amount=Decimal("110"), currency="EUR"),
+        step_index=0,
+    )
+    assert res.bankroll_after.amount == Decimal("110.00")


### PR DESCRIPTION
## Summary
- add Match, Odds, Prediction and StrategyResult entities
- support MatchStatus and PredictionStatus enums
- provide helpers for odds and prediction EV calculations
- cover domain entities with tests

## Testing
- `ruff check`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a762d23430832b8c5e40ea09d4a687