### PR TITLE
Add typed interfaces for predictive models and strategies

### DIFF
--- a/src/domain/interfaces/__init__.py
+++ b/src/domain/interfaces/__init__.py
@@ -1,0 +1,15 @@
+"""Core interfaces for predictive models and betting strategies."""
+
+from .context import ModelContext
+from .enums import PredictionStatus
+from .modeling import BasePredictiveModel, PredictionAggregator
+from .strategies import BaseStrategy, StrategyRunner
+
+__all__ = [
+    "PredictionStatus",
+    "ModelContext",
+    "BasePredictiveModel",
+    "PredictionAggregator",
+    "BaseStrategy",
+    "StrategyRunner",
+]

--- a/src/domain/interfaces/context.py
+++ b/src/domain/interfaces/context.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from ..value_objects.enums import ModelName
+from ..value_objects.ids import FixtureId, LeagueId, TeamId
+
+
+class ModelContext(BaseModel):
+    """Input data shared across predictive models.
+
+    >>> ctx = ModelContext(fixture_id=FixtureId(1), league_id=LeagueId(1), season=2024)
+    >>> ctx.has_minimal_inputs_for(ModelName.POISSON)
+    False
+    """
+
+    fixture_id: FixtureId
+    league_id: LeagueId
+    season: int
+    home_team_id: TeamId | None = None
+    away_team_id: TeamId | None = None
+    home_goal_rate: float | None = None
+    away_goal_rate: float | None = None
+    elo_home: float | None = None
+    elo_away: float | None = None
+    home_advantage: float | None = None
+    features: dict[str, float] | None = None
+
+    model_config = ConfigDict(frozen=True)
+
+    def has_minimal_inputs_for(self, model: ModelName) -> bool:
+        """Return whether minimal inputs exist for ``model``.
+
+        The check is heuristic; models may enforce stricter rules.
+
+        >>> ctx = ModelContext(
+        ...     fixture_id=FixtureId(1),
+        ...     league_id=LeagueId(1),
+        ...     season=2024,
+        ...     home_goal_rate=1.2,
+        ...     away_goal_rate=0.8,
+        ... )
+        >>> ctx.has_minimal_inputs_for(ModelName.POISSON)
+        True
+        """
+
+        match model:
+            case ModelName.POISSON:
+                return self.home_goal_rate is not None and self.away_goal_rate is not None
+            case ModelName.ELO:
+                return self.elo_home is not None and self.elo_away is not None
+            case ModelName.LOGISTIC_REGRESSION:
+                return self.features is not None
+            case _:
+                return True

--- a/src/domain/interfaces/enums.py
+++ b/src/domain/interfaces/enums.py
@@ -1,0 +1,12 @@
+from enum import StrEnum
+
+
+class PredictionStatus(StrEnum):
+    """Status of a prediction.
+
+    >>> PredictionStatus.OK.value
+    'OK'
+    """
+
+    OK = "OK"
+    SKIPPED = "SKIPPED"

--- a/src/domain/interfaces/modeling.py
+++ b/src/domain/interfaces/modeling.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import ClassVar, Protocol
+
+from ..entities.match import Match
+from ..entities.prediction import Prediction
+from ..value_objects.enums import ModelName
+from .context import ModelContext
+
+
+class BasePredictiveModel(ABC):
+    """Base class for predictive models.
+
+    >>> from datetime import datetime, timezone
+    >>> from src.domain.interfaces.enums import PredictionStatus
+    >>> from src.domain.value_objects.probability_triplet import ProbabilityTriplet
+    >>> class AlwaysHome(BasePredictiveModel):
+    ...     name = ModelName.POISSON
+    ...     version = "0"
+    ...     def predict(self, match: Match, ctx: ModelContext) -> Prediction:
+    ...         probs = ProbabilityTriplet(home=1.0, draw=0.0, away=0.0)
+    ...         return Prediction(
+    ...             fixture_id=match.fixture_id,
+    ...             model=self.name,
+    ...             probs=probs,
+    ...             computed_at_utc=datetime.now(timezone.utc),
+    ...             version=self.version,
+    ...             status=PredictionStatus.OK,
+    ...         )
+    >>> isinstance(AlwaysHome().predict, object)
+    True
+    """
+
+    name: ClassVar[ModelName]
+    version: ClassVar[str]
+
+    @abstractmethod
+    def predict(self, match: Match, ctx: ModelContext) -> Prediction:
+        """Return a prediction for ``match`` using ``ctx``.
+
+        When required inputs are missing, implementations should return a
+        ``Prediction`` with ``status=PredictionStatus.SKIPPED`` and provide a
+        ``skip_reason`` instead of raising exceptions.
+        """
+
+
+class PredictionAggregator(Protocol):
+    """Protocol for running multiple predictive models.
+
+    >>> agg.run_all([model], match, ctx)  # doctest: +SKIP
+    [Prediction(...)]
+    """
+
+    def run_all(
+        self, models: list[BasePredictiveModel], match: Match, ctx: ModelContext
+    ) -> list[Prediction]: ...

--- a/src/domain/interfaces/strategies.py
+++ b/src/domain/interfaces/strategies.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import ClassVar, Protocol
+
+from ..entities.odds import Odds
+from ..entities.prediction import Prediction
+from ..entities.strategy_result import StrategyResult
+from ..value_objects.enums import Outcome, StrategyName
+from ..value_objects.money import Money
+
+
+class BaseStrategy(ABC):
+    """Base class for betting strategies.
+
+    >>> class Flat1Unit(BaseStrategy):
+    ...     name = StrategyName.FLAT
+    ...     version = "1.0"
+    ...     def run(
+    ...         self,
+    ...         *,
+    ...         bankroll: Money,
+    ...         odds: Odds,
+    ...         prediction: Prediction,
+    ...         outcome: Outcome | None = None,
+    ...         step_index: int = 0,
+    ...     ) -> StrategyResult:
+    ...         profit = Money(amount=0)
+    ...         return StrategyResult(
+    ...             fixture_id=odds.fixture_id,
+    ...             strategy=self.name,
+    ...             model=prediction.model,
+    ...             outcome=Outcome.HOME,
+    ...             stake=bankroll,
+    ...             odds=odds.home,
+    ...             result=None,
+    ...             profit=profit,
+    ...             bankroll_after=bankroll,
+    ...             step_index=step_index,
+    ...         )
+    >>> isinstance(Flat1Unit().run, object)
+    True
+    """
+
+    name: ClassVar[StrategyName]
+    version: ClassVar[str]
+
+    @abstractmethod
+    def run(
+        self,
+        *,
+        bankroll: Money,
+        odds: Odds,
+        prediction: Prediction,
+        outcome: Outcome | None = None,
+        step_index: int = 0,
+    ) -> StrategyResult:
+        """Execute one betting step and return the result.
+
+        Negative profit is possible and indicates a loss.
+        """
+
+
+class StrategyRunner(Protocol):
+    """Protocol for running a strategy on a sequence of events.
+
+    >>> runner.simulate(strategy, seq, bankroll)  # doctest: +SKIP
+    [StrategyResult(...)]
+    """
+
+    def simulate(
+        self, strategy: BaseStrategy, sequence: list[tuple[Odds, Prediction]], bankroll: Money
+    ) -> list[StrategyResult]: ...

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Literal
+
+from src.domain.entities.match import Match
+from src.domain.entities.odds import Odds
+from src.domain.entities.prediction import Prediction
+from src.domain.entities.strategy_result import StrategyResult
+from src.domain.interfaces.context import ModelContext
+from src.domain.interfaces.enums import PredictionStatus
+from src.domain.interfaces.modeling import BasePredictiveModel
+from src.domain.interfaces.strategies import BaseStrategy
+from src.domain.value_objects.enums import (
+    MatchStatus,
+    ModelName,
+    Outcome,
+    StrategyName,
+)
+from src.domain.value_objects.enums import (
+    PredictionStatus as PredictionStatusVO,
+)
+from src.domain.value_objects.ids import BookmakerId, FixtureId, LeagueId
+from src.domain.value_objects.money import Money
+from src.domain.value_objects.probability_triplet import ProbabilityTriplet
+
+
+class DummyAlwaysHome(BasePredictiveModel):
+    name = ModelName.POISSON
+    version = "0"
+
+    def predict(self, match: Match, ctx: ModelContext) -> Prediction:
+        probs = ProbabilityTriplet(home=1.0, draw=0.0, away=0.0)
+        return Prediction(
+            fixture_id=match.fixture_id,
+            model=self.name,
+            probs=probs,
+            computed_at_utc=datetime.now(timezone.utc),
+            version=self.version,
+            status=PredictionStatusVO(PredictionStatus.OK.value),
+        )
+
+
+class Flat1Unit(BaseStrategy):
+    name = StrategyName.FLAT
+    version = "1.0"
+
+    def run(
+        self,
+        *,
+        bankroll: Money,
+        odds: Odds,
+        prediction: Prediction,
+        outcome: Outcome | None = None,
+        step_index: int = 0,
+    ) -> StrategyResult:
+        stake = Money(amount=Decimal("1"), currency=bankroll.currency)
+        target = Outcome.HOME
+        result: Literal["WIN", "LOSE", "VOID"] | None
+        if outcome == target:
+            result = "WIN"
+            profit = stake * (odds.home - Decimal("1"))
+        elif outcome is None:
+            result = None
+            profit = Money(amount=Decimal("0"), currency=bankroll.currency)
+        else:
+            result = "LOSE"
+            profit = stake * Decimal("-1")
+        bankroll_after = bankroll + profit
+        return StrategyResult(
+            fixture_id=odds.fixture_id,
+            strategy=self.name,
+            model=prediction.model,
+            outcome=target,
+            stake=stake,
+            odds=odds.home,
+            result=result,
+            profit=profit,
+            bankroll_after=bankroll_after,
+            step_index=step_index,
+        )
+
+
+def test_dummy_model_and_strategy() -> None:
+    match = Match(
+        fixture_id=FixtureId(1),
+        league_id=LeagueId(1),
+        season=2024,
+        kickoff_utc=datetime.now(timezone.utc),
+        home_name="A",
+        away_name="B",
+        status=MatchStatus.SCHEDULED,
+    )
+    ctx = ModelContext(fixture_id=match.fixture_id, league_id=match.league_id, season=match.season)
+    model = DummyAlwaysHome()
+    pred = model.predict(match, ctx)
+    assert pred.status == PredictionStatus.OK
+    odds = Odds(
+        fixture_id=match.fixture_id,
+        bookmaker_id=BookmakerId(1),
+        collected_at_utc=datetime.now(timezone.utc),
+        home=Decimal("2.0"),
+        draw=Decimal("3.0"),
+        away=Decimal("4.0"),
+    )
+    strat = Flat1Unit()
+    bankroll = Money(amount=Decimal("10"))
+    result = strat.run(bankroll=bankroll, odds=odds, prediction=pred, outcome=Outcome.HOME)
+    assert isinstance(result, StrategyResult)
+    assert result.bankroll_after.amount > bankroll.amount


### PR DESCRIPTION
## Summary
- define `PredictionStatus` enum for model responses
- provide `ModelContext` value object with optional inputs and heuristics
- introduce `BasePredictiveModel` and `BaseStrategy` abstract interfaces plus protocol helpers
- add smoke tests with dummy model and flat staking strategy

## Testing
- `black src/domain/interfaces tests/test_interfaces.py`
- `ruff check src/domain/interfaces tests/test_interfaces.py`
- `mypy src/domain/interfaces tests/test_interfaces.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a77068beb8832ba041e4bcf7e0144c