### PR TITLE
feat: add StrEnum fallback

### DIFF
--- a/src/domain/interfaces/enums.py
+++ b/src/domain/interfaces/enums.py
@@ -1,4 +1,19 @@
-from enum import StrEnum
+"""Enum definitions for the interfaces layer.
+
+This module previously relied on :class:`enum.StrEnum`, which is only
+available starting from Python 3.11.  The project needs to run on earlier
+Python versions as well, so we provide a small compatibility layer that
+defines :class:`StrEnum` when it's not available.  The fallback behaves like a
+regular ``Enum`` whose members are also ``str`` instances.
+"""
+
+try:  # pragma: no cover - import error handling is trivial
+    from enum import StrEnum
+except ImportError:  # Python < 3.11
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Backport of :class:`enum.StrEnum` for older Python versions."""
 
 
 class PredictionStatus(StrEnum):


### PR DESCRIPTION
## Summary
- ensure enums work on Python <3.11 by providing a StrEnum fallback

## Testing
- `python -m pytest --cov=src --cov-report=xml --cov-report=term`
- `pre-commit run --files src/domain/interfaces/enums.py` *(fails: command not found; attempted installation but could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a77cafe5ec832b9da802ff9280b0e3