### PR TITLE
Add SQLite migration support and base schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.egg-info/
 .eggs/
 *.sqlite3
+otdk.db
 
 # Virtual env
 .venv/

--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -1,0 +1,43 @@
+"""Simple SQLite migration runner."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+MIGRATIONS_DIR = Path(__file__).resolve().parent / "migrations"
+DB_PATH = ROOT / "otdk.db"
+
+
+def applied_versions(cursor: sqlite3.Cursor) -> set[str]:
+    cursor.execute("CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY)")
+    rows = cursor.execute("SELECT version FROM schema_migrations").fetchall()
+    return {row[0] for row in rows}
+
+
+def available_migrations() -> Iterable[tuple[str, Path]]:
+    pattern = re.compile(r"V(\d+)__.+\.sql$")
+    for path in sorted(MIGRATIONS_DIR.glob("V*__*.sql")):
+        match = pattern.match(path.name)
+        if match:
+            yield match.group(1), path
+
+
+def run_migrations() -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.cursor()
+        done = applied_versions(cursor)
+        for version, path in available_migrations():
+            if version in done:
+                continue
+            sql = path.read_text()
+            cursor.executescript(sql)
+            cursor.execute("INSERT INTO schema_migrations (version) VALUES (?)", (version,))
+            conn.commit()
+
+
+if __name__ == "__main__":
+    run_migrations()

--- a/src/db/migrations/V1__base.sql
+++ b/src/db/migrations/V1__base.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS matches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    league_id TEXT,
+    home_team TEXT,
+    away_team TEXT,
+    date TEXT,
+    status TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS simulations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    match_id INTEGER REFERENCES matches(id),
+    strategy TEXT,
+    model TEXT,
+    profit REAL DEFAULT 0.0,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS odds (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    match_id INTEGER REFERENCES matches(id),
+    bookmaker_id TEXT,
+    home_win REAL,
+    draw REAL,
+    away_win REAL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS predictions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    match_id INTEGER REFERENCES matches(id),
+    model TEXT,
+    p_home REAL,
+    p_draw REAL,
+    p_away REAL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- add SQLite migration runner that records applied versions and executes new SQL migrations
- introduce initial `V1__base` migration for matches, simulations, odds, and predictions tables
- ignore local `otdk.db` database file

## Testing
- `black src/db/migrate.py`
- `ruff check src/db/migrate.py`
- `mypy src/db/migrate.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a78924275c832bb34bac0b26a22d42