### PR TITLE
Format repository modules with Ruff

### DIFF
--- a/src/repositories/odds.py
+++ b/src/repositories/odds.py
@@ -23,9 +23,7 @@ class OddsRepo(ABC):
         """Return odds by identifier if present."""
 
     @abstractmethod
-    def list_by_match(
-        self, match_id: int, *, limit: int = 100, offset: int = 0
-    ) -> list[Odds]:
+    def list_by_match(self, match_id: int, *, limit: int = 100, offset: int = 0) -> list[Odds]:
         """List odds entries for a given match."""
 
     @abstractmethod

--- a/src/repositories/sqlite/bookmakers_sqlite.py
+++ b/src/repositories/sqlite/bookmakers_sqlite.py
@@ -22,9 +22,7 @@ class BookmakersRepoSqlite(BookmakersRepo):
         self._conn.commit()
 
     def get_by_id(self, bookmaker_id: int) -> Optional[Bookmaker]:
-        cur = self._conn.execute(
-            "SELECT id, name FROM bookmakers WHERE id = ?", (bookmaker_id,)
-        )
+        cur = self._conn.execute("SELECT id, name FROM bookmakers WHERE id = ?", (bookmaker_id,))
         row = cur.fetchone()
         if row:
             return Bookmaker(*row)
@@ -37,9 +35,7 @@ class BookmakersRepoSqlite(BookmakersRepo):
         return [Bookmaker(*row) for row in cur.fetchall()]
 
     def insert(self, bookmaker: Bookmaker) -> int:
-        cur = self._conn.execute(
-            "INSERT INTO bookmakers (name) VALUES (?)", (bookmaker.name,)
-        )
+        cur = self._conn.execute("INSERT INTO bookmakers (name) VALUES (?)", (bookmaker.name,))
         self._conn.commit()
         return cur.lastrowid
 

--- a/src/repositories/sqlite/leagues_sqlite.py
+++ b/src/repositories/sqlite/leagues_sqlite.py
@@ -22,24 +22,18 @@ class LeaguesRepoSqlite(LeaguesRepo):
         self._conn.commit()
 
     def get_by_id(self, league_id: int) -> Optional[League]:
-        cur = self._conn.execute(
-            "SELECT id, name FROM leagues WHERE id = ?", (league_id,)
-        )
+        cur = self._conn.execute("SELECT id, name FROM leagues WHERE id = ?", (league_id,))
         row = cur.fetchone()
         if row:
             return League(*row)
         return None
 
     def list_all(self, *, limit: int = 100, offset: int = 0) -> list[League]:
-        cur = self._conn.execute(
-            "SELECT id, name FROM leagues LIMIT ? OFFSET ?", (limit, offset)
-        )
+        cur = self._conn.execute("SELECT id, name FROM leagues LIMIT ? OFFSET ?", (limit, offset))
         return [League(*row) for row in cur.fetchall()]
 
     def insert(self, league: League) -> int:
-        cur = self._conn.execute(
-            "INSERT INTO leagues (name) VALUES (?)", (league.name,)
-        )
+        cur = self._conn.execute("INSERT INTO leagues (name) VALUES (?)", (league.name,))
         self._conn.commit()
         return cur.lastrowid
 

--- a/src/repositories/sqlite/odds_sqlite.py
+++ b/src/repositories/sqlite/odds_sqlite.py
@@ -43,9 +43,7 @@ class OddsRepoSqlite(OddsRepo):
             return Odds(*row)
         return None
 
-    def list_by_match(
-        self, match_id: int, *, limit: int = 100, offset: int = 0
-    ) -> list[Odds]:
+    def list_by_match(self, match_id: int, *, limit: int = 100, offset: int = 0) -> list[Odds]:
         cur = self._conn.execute(
             "SELECT id, match_id, bookmaker_id, home, draw, away FROM odds WHERE match_id = ? LIMIT ? OFFSET ?",
             (match_id, limit, offset),

--- a/src/repositories/sqlite/predictions_sqlite.py
+++ b/src/repositories/sqlite/predictions_sqlite.py
@@ -62,13 +62,13 @@ class PredictionsRepoSqlite(PredictionsRepo):
             INSERT INTO predictions (match_id, prob_home, prob_draw, prob_away, is_correct)
             VALUES (?, ?, ?, ?, ?)
             """,
-        (
-            prediction.match_id,
-            prediction.prob_home,
-            prediction.prob_draw,
-            prediction.prob_away,
-            int(prediction.is_correct) if prediction.is_correct is not None else None,
-        ),
+            (
+                prediction.match_id,
+                prediction.prob_home,
+                prediction.prob_draw,
+                prediction.prob_away,
+                int(prediction.is_correct) if prediction.is_correct is not None else None,
+            ),
         )
         self._conn.commit()
         return cur.lastrowid


### PR DESCRIPTION
## Summary
- Apply Ruff formatting to repository interfaces and SQLite implementations

## Testing
- `python -m ruff format --check .`
- `python -m ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a79a31da58832bae3d4ae2e925b3ab