### PR TITLE
Add tests for configuration and interfaces coverage

### DIFF
--- a/tests/test_interfaces_extra.py
+++ b/tests/test_interfaces_extra.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+
+from src.domain.interfaces.context import ModelContext
+from src.domain.value_objects.enums import ModelName
+from src.domain.value_objects.ids import FixtureId, LeagueId
+
+
+def test_model_context_minimal_inputs() -> None:
+    ctx = ModelContext(fixture_id=FixtureId(1), league_id=LeagueId(1), season=2024)
+    assert not ctx.has_minimal_inputs_for(ModelName.POISSON)
+    ctx_poisson = ctx.model_copy(update={"home_goal_rate": 1.0, "away_goal_rate": 1.0})
+    assert ctx_poisson.has_minimal_inputs_for(ModelName.POISSON)
+    ctx_elo = ctx.model_copy(update={"elo_home": 1.0, "elo_away": 1.0})
+    assert ctx_elo.has_minimal_inputs_for(ModelName.ELO)
+    ctx_lr = ctx.model_copy(update={"features": {"x": 0.5}})
+    assert ctx_lr.has_minimal_inputs_for(ModelName.LOGISTIC_REGRESSION)
+    assert ctx.has_minimal_inputs_for("something")
+
+
+def test_strenum_backport(monkeypatch):
+    module_name = "src.domain.interfaces.enums"
+    mod = importlib.import_module(module_name)
+    original_version = sys.version_info
+    monkeypatch.setattr(sys, "version_info", (3, 10))
+    mod = importlib.reload(mod)
+    assert issubclass(mod.StrEnum, str)
+    assert issubclass(mod.StrEnum, mod.Enum)
+    monkeypatch.setattr(sys, "version_info", original_version)
+    importlib.reload(mod)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,50 @@
+import importlib
+import sys
+import pytest
+
+MODULE = "src.config.settings"
+
+
+def reload_settings():
+    return importlib.reload(importlib.import_module(MODULE))
+
+
+def test_direct_api_settings(monkeypatch):
+    monkeypatch.setenv("API_KEY", "secret")
+    monkeypatch.delenv("USE_RAPIDAPI", raising=False)
+    monkeypatch.delenv("RAPIDAPI_KEY", raising=False)
+    module = reload_settings()
+    assert module.settings.base_url == module.DIRECT_BASE_URL
+    assert module.settings.headers == {"x-apisports-key": "secret"}
+
+
+def test_rapidapi_settings(monkeypatch):
+    monkeypatch.setenv("USE_RAPIDAPI", "true")
+    monkeypatch.setenv("RAPIDAPI_KEY", "rk")
+    monkeypatch.delenv("API_KEY", raising=False)
+    module = reload_settings()
+    assert module.settings.base_url == module.RAPIDAPI_BASE_URL
+    assert module.settings.headers == {
+        "x-rapidapi-host": "api-football-v1.p.rapidapi.com",
+        "x-rapidapi-key": "rk",
+    }
+
+
+def test_rapidapi_requires_key(monkeypatch):
+    monkeypatch.setenv("USE_RAPIDAPI", "true")
+    monkeypatch.delenv("RAPIDAPI_KEY", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        reload_settings()
+
+
+def test_direct_requires_api_key(monkeypatch):
+    monkeypatch.setenv("API_KEY", "temp")
+    module = reload_settings()
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.delenv("RAPIDAPI_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="No API access key provided"):
+        module._build_settings()
+    monkeypatch.setenv("RAPIDAPI_KEY", "rk")
+    with pytest.raises(RuntimeError, match="API_KEY is required"):
+        module._build_settings()


### PR DESCRIPTION
## Summary
- test API settings for direct and RapidAPI modes, including error scenarios
- cover ModelContext minimal-input validation and StrEnum backport logic

## Testing
- `pytest`
- `coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_68a79d14c338832ba510791ebe2d6a62